### PR TITLE
Drop the connection on context cancellation

### DIFF
--- a/wsutil.go
+++ b/wsutil.go
@@ -160,7 +160,10 @@ func (p *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	go cp(d, nc)
 	go cp(nc, d)
-	<-errc
+	select {
+	case <-errc:
+	case <-r.Context().Done():
+	}
 }
 
 // IsWebSocketRequest returns a boolean indicating whether the request has the


### PR DESCRIPTION
This should be safe:
- `r.Context()` is always non-nil
- `r.Context().Done()` can be nil, but reading from nil channels just blocks forever